### PR TITLE
Implementing honey level functionality.

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/config/Configs.java
+++ b/src/main/java/fi/dy/masa/minihud/config/Configs.java
@@ -35,6 +35,7 @@ public class Configs implements IConfigHandler
     public static class Generic
     {
         public static final ConfigBoolean       BEE_TOOLTIPS                        = new ConfigBoolean("beeTooltips", false, "Adds the number of contained bees to the tooltip of Bee Hive and Bee Nest items");
+        public static final ConfigBoolean       HONEY_TOOLTIPS                      = new ConfigBoolean("honeyTooltips", false, "Adds the honey level to the tooltip of Bee Hive and Bee Nest items");
         public static final ConfigOptionList    BLOCK_GRID_OVERLAY_MODE             = new ConfigOptionList("blockGridOverlayMode", BlockGridMode.ALL, "The block grid render mode");
         public static final ConfigInteger       BLOCK_GRID_OVERLAY_RADIUS           = new ConfigInteger("blockGridOverlayRadius", 32, "The radius of the block grid lines to render");
         public static final ConfigString        COORDINATE_FORMAT_STRING            = new ConfigString("coordinateFormat", "x: %.1f y: %.1f z: %.1f", "The format string for the coordinate line.\nNeeds to have three %f format strings!\nDefault: x: %.1f y: %.1f z: %.1f");
@@ -82,6 +83,7 @@ public class Configs implements IConfigHandler
 
         public static final ImmutableList<IConfigBase> OPTIONS = ImmutableList.of(
                 BEE_TOOLTIPS,
+                HONEY_TOOLTIPS,
                 ENABLED,
                 DEBUG_RENDERER_PATH_MAX_DIST,
                 DONT_RESET_SEED_ON_DIMENSION_CHANGE,

--- a/src/main/java/fi/dy/masa/minihud/config/InfoToggle.java
+++ b/src/main/java/fi/dy/masa/minihud/config/InfoToggle.java
@@ -14,6 +14,7 @@ import fi.dy.masa.minihud.MiniHUD;
 public enum InfoToggle implements IConfigInteger, IHotkeyTogglable
 {
     BEE_COUNT               ("infoBeeCount",                false, 36, "", "Show the number of bees in the targeted Hive or Nest.\nNote: This only works in single player without server-side support."),
+    HONEY_LEVEL             ("infoHoneyLevel",              false, 37, "", "Show the honey level the targeted Hive or Nest.\nNote: This only works in single player without server-side support."),
     BIOME                   ("infoBiome",                   false, 19, "", "Show the name of the current biome"),
     BIOME_REG_NAME          ("infoBiomeRegistryName",       false, 20, "", "Show the registry name of the current biome"),
     BLOCK_IN_CHUNK          ("infoBlockInChunk",            false, 28, "", "Show the player's current position within the Chunk"),

--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -563,6 +563,16 @@ public class RenderHandler implements IRenderer
                 this.addLine("Bees: " + GuiBase.TXT_AQUA + ((BeehiveBlockEntity) be).getBeeCount());
             }
         }
+        else if (type == InfoToggle.HONEY_LEVEL)
+        {
+            World bestWorld = WorldUtils.getBestWorld(mc);
+            BlockEntity be = this.getTargetedBlockEntity(bestWorld, mc);
+
+            if (be instanceof BeehiveBlockEntity)
+            {
+                this.addLine("Honey: " + GuiBase.TXT_AQUA + ((BeehiveBlockEntity) be).getHoneyLevel());
+            }
+        }
         else if (type == InfoToggle.ROTATION_YAW ||
                  type == InfoToggle.ROTATION_PITCH ||
                  type == InfoToggle.SPEED)

--- a/src/main/java/fi/dy/masa/minihud/mixin/MixinItemStack.java
+++ b/src/main/java/fi/dy/masa/minihud/mixin/MixinItemStack.java
@@ -33,5 +33,12 @@ public abstract class MixinItemStack
         {
             MiscUtils.addBeeTooltip((ItemStack) (Object) this, list);
         }
+
+        if (Configs.Generic.HONEY_TOOLTIPS.getBooleanValue() &&
+            this.getItem() instanceof BlockItem &&
+            ((BlockItem) this.getItem()).getBlock() instanceof BeehiveBlock)
+        {
+            MiscUtils.addHoneyTooltip((ItemStack) (Object) this, list);
+        }
     }
 }

--- a/src/main/java/fi/dy/masa/minihud/util/MiscUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/MiscUtils.java
@@ -97,4 +97,25 @@ public class MiscUtils
             lines.add(Math.min(1, lines.size()), new TranslatableText("minihud.label.bee_info.count", String.valueOf(count)));
         }
     }
+
+    @Nullable
+    public static void addHoneyTooltip(ItemStack stack, List<Text> lines)
+    {
+        CompoundTag tag = stack.getTag();
+
+        if (tag != null && tag.contains("BlockStateTag", Constants.NBT.TAG_COMPOUND))
+        {
+            tag = tag.getCompound("BlockStateTag");
+            String honeyLevel = "0";
+            if (tag != null && tag.contains("honey_level", Constants.NBT.TAG_STRING))
+            {
+                honeyLevel = tag.getString("honey_level");
+            }
+            else if (tag != null && tag.contains("honey_level", Constants.NBT.TAG_INT))
+            {
+                honeyLevel = Integer.toString(tag.getString("honey_level"));
+            }
+            lines.add(Math.min(1, lines.size()), new TranslatableText("minihud.label.honey_info.level", String.valueOf(beeName)));
+        }
+    }
 }

--- a/src/main/resources/assets/minihud/lang/en_us.json
+++ b/src/main/resources/assets/minihud/lang/en_us.json
@@ -28,6 +28,8 @@
     "minihud.label.bee_info.count": "§7Contains §b%s§7 bee(s)",
     "minihud.label.bee_info.name": "§7- %s",
 
+    "minihud.label.honey_info.level": "§7Honey level is §b%s§7/5",
+
     "minihud.label.blockgridmode.all": "All",
     "minihud.label.blockgridmode.non_air": "Non-air",
     "minihud.label.blockgridmode.adjacent": "Adjacent to non-air",


### PR DESCRIPTION
This pull request adds 2 honey related features:
- A new setting for adding honey level info to the tooltip of bee hives and nests.
- A new setting for adding honey level info to the HUD when looking at a bee hive or nest.

I am currently unable to test this code, but I hope you will find it works fine when you test it yourself. My apologies for this inconvenience.

The tooltip code contains a conditional that checks for a string or an int value for 'honey_level', this is because of a vanilla minecraft bug where the gamemode of the player  when breaking a hive/nest affects what datatype is used.

This bug is reported and confirmed here: https://bugs.mojang.com/browse/MC-179531