### PR TITLE
Add Navigation Line shape

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/config/Configs.java
+++ b/src/main/java/fi/dy/masa/minihud/config/Configs.java
@@ -164,6 +164,7 @@ public class Configs implements IConfigHandler
         public static final ConfigColor SHAPE_CIRCLE                            = new ConfigColor("shapeCircle",                        "#6030B0B0", "Default color for the Circle renderer.\nThe color can be changed for each shape via its configuration GUI.");
         public static final ConfigColor SHAPE_DESPAWN_SPHERE                    = new ConfigColor("shapeDespawnSphere",                 "#60A04050", "Default color for the \"Despawn Sphere\" overlay.\nThe color can be changed for each sphere via its configuration GUI.");
         public static final ConfigColor SHAPE_SPHERE_BLOCKY                     = new ConfigColor("shapeSphereBlocky",                  "#6030B0B0", "Default color for the blocky/block-based Sphere renderer.\nThe color can be changed for each sphere via its configuration GUI.");
+        public static final ConfigColor SHAPE_NAVIGATION_LINE                   = new ConfigColor("shapeNavigationLine",                "#80E3D8F1", "Default color for the \"Navigation Line\" overlay.\nThe color can be changed for each sphere via its configuration GUI.");
         public static final ConfigColor SLIME_CHUNKS_OVERLAY_COLOR              = new ConfigColor("slimeChunksOverlayColor",            "#3020F020", "Color for the slime chunks overlay");
         public static final ConfigColor SPAWN_PLAYER_ENTITY_OVERLAY_COLOR       = new ConfigColor("spawnPlayerEntityOverlayColor",      "#302050D0", "Color for the entity-processing would-be spawn chunks overlay of\nhow the spawn chunks would be if the spawn were\nto be at the player's current position");
         public static final ConfigColor SPAWN_PLAYER_LAZY_OVERLAY_COLOR         = new ConfigColor("spawnPlayerLazyOverlayColor",        "#30D030D0", "Color for the \"lazy-loaded\" would-be spawn chunks overlay of\nhow the spawn chunks would be if the spawn were\nto be at the player's current position");
@@ -191,6 +192,7 @@ public class Configs implements IConfigHandler
                 SHAPE_CIRCLE,
                 SHAPE_DESPAWN_SPHERE,
                 SHAPE_SPHERE_BLOCKY,
+                SHAPE_NAVIGATION_LINE,
                 SLIME_CHUNKS_OVERLAY_COLOR,
                 SPAWN_PLAYER_ENTITY_OVERLAY_COLOR,
                 SPAWN_PLAYER_LAZY_OVERLAY_COLOR,

--- a/src/main/java/fi/dy/masa/minihud/gui/GuiShapeEditor.java
+++ b/src/main/java/fi/dy/masa/minihud/gui/GuiShapeEditor.java
@@ -39,6 +39,7 @@ import fi.dy.masa.minihud.gui.GuiConfigs.ConfigGuiTab;
 import fi.dy.masa.minihud.renderer.shapes.ShapeBase;
 import fi.dy.masa.minihud.renderer.shapes.ShapeCircle;
 import fi.dy.masa.minihud.renderer.shapes.ShapeCircleBase;
+import fi.dy.masa.minihud.renderer.shapes.ShapeNavigationLine;
 import fi.dy.masa.minihud.renderer.shapes.ShapeSpawnSphere;
 import fi.dy.masa.minihud.util.ShapeRenderType;
 
@@ -131,6 +132,10 @@ public class GuiShapeEditor extends GuiRenderLayerEditBase
                 this.createShapeEditorElementsSphereBase(x, y, true);
                 this.createRenderTypeButton(renderTypeX, renderTypeY, () -> this.shape.getRenderType(), (val) -> this.shape.setRenderType(val), "minihud.gui.label.render_type_colon");
                 break;
+
+            case NAVIGATION_LINE:
+                this.createShapeEditorElementsNavigationLine(x, y);
+                break;
         }
     }
 
@@ -160,6 +165,21 @@ public class GuiShapeEditor extends GuiRenderLayerEditBase
         this.addButton(buttonSnap, new ButtonListenerSphereBlockSnap(shape, this));
 
         y += 34;
+
+        this.createColorInput(x, y);
+    }
+
+    private void createShapeEditorElementsNavigationLine(int x, int y)
+    {
+        this.addLabel(x, y, 60, 14, 0xFFFFFFFF, StringUtils.translate("minihud.gui.label.destination_colon"));
+        y += 12;
+        ShapeNavigationLine shape = (ShapeNavigationLine) this.shape;
+        GuiUtils.createVec3dInputsVertical(x, y, 120, shape.getDestination(), new NavigationLineEditor(shape, this), true, this);
+        y += 54;
+
+        ButtonGeneric button = new ButtonGeneric(x + 11, y, -1, false, "malilib.gui.button.render_layers_gui.set_to_player");
+        this.addButton(button, new ButtonListenerNavigationLine(shape, this));
+        y += 24;
 
         this.createColorInput(x, y);
     }
@@ -286,6 +306,63 @@ public class GuiShapeEditor extends GuiRenderLayerEditBase
                 this.shape.setCenter(entity.getPos());
                 this.gui.initGui();
             }
+        }
+    }
+
+    private static class ButtonListenerNavigationLine implements IButtonActionListener
+    {
+        private final GuiShapeEditor gui;
+        private final ShapeNavigationLine shape;
+
+        private ButtonListenerNavigationLine(ShapeNavigationLine shape, GuiShapeEditor gui)
+        {
+            this.shape = shape;
+            this.gui = gui;
+        }
+
+        @Override
+        public void actionPerformedWithButton(ButtonBase button, int mouseButton)
+        {
+            Entity entity = this.gui.mc.getCameraEntity();
+
+            if (entity != null)
+            {
+                this.shape.setDestination(entity.getPos());
+                this.gui.initGui();
+            }
+        }
+    }
+
+    private static class NavigationLineEditor implements ICoordinateValueModifier
+    {
+        private final GuiShapeEditor gui;
+        private final ShapeNavigationLine shape;
+
+        private NavigationLineEditor(ShapeNavigationLine shape, GuiShapeEditor gui)
+        {
+            this.shape = shape;
+            this.gui = gui;
+        }
+
+        @Override
+        public boolean modifyValue(CoordinateType type, int amount)
+        {
+            this.shape.setDestination(PositionUtils.modifyValue(type, this.shape.getDestination(), amount));
+            this.gui.initGui();
+            return true;
+        }
+
+        @Override
+        public boolean setValueFromString(CoordinateType type, String newValue)
+        {
+            try
+            {
+                this.shape.setDestination(PositionUtils.setValue(type, this.shape.getDestination(), Double.parseDouble(newValue)));
+                return true;
+            }
+            catch (Exception e) {}
+
+            return false;
         }
     }
 

--- a/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeNavigationLine.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeNavigationLine.java
@@ -1,0 +1,156 @@
+package fi.dy.masa.minihud.renderer.shapes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.lwjgl.opengl.GL11;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import fi.dy.masa.malilib.util.Color4f;
+import fi.dy.masa.malilib.util.EntityUtils;
+import fi.dy.masa.malilib.util.JsonUtils;
+import fi.dy.masa.malilib.util.StringUtils;
+import fi.dy.masa.minihud.config.Configs;
+import fi.dy.masa.minihud.renderer.RenderObjectBase;
+
+public class ShapeNavigationLine extends ShapeBase
+{
+    protected Vec3d destination = Vec3d.ZERO;
+    protected Vec3d lastUpdatePos = Vec3d.ZERO;
+    protected long lastUpdateTime;
+    private static float WIDTH = 0.0001f;
+
+    public ShapeNavigationLine()
+    {
+        super(ShapeType.NAVIGATION_LINE, Configs.Colors.SHAPE_NAVIGATION_LINE.getColor());
+
+        Entity entity = EntityUtils.getCameraEntity();
+
+        if (entity != null)
+        {
+            Vec3d center = entity.getPos();
+            center = new Vec3d(Math.floor(center.x) + 0.5, Math.floor(center.y), Math.floor(center.z) + 0.5);
+            this.setDestination(this.mc.player.getPos());
+        }
+        else
+        {
+            this.setDestination(Vec3d.ZERO);
+        }
+        this.setNeedsUpdate();
+    }
+
+    public void setDestination(Vec3d destination)
+    {
+        this.destination = destination;
+        this.setNeedsUpdate();
+    }
+
+    public Vec3d getDestination() {
+        return this.destination;
+    }
+
+    @Override
+    public void update(Vec3d cameraPos, Entity entity, MinecraftClient mc)
+    {
+        RenderSystem.lineWidth(100f);
+        this.renderLine(cameraPos);
+        RenderSystem.lineWidth(1f);
+
+        this.lastUpdatePos = entity.getPos();
+        this.lastUpdateTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public void allocateGlResources()
+    {
+        this.allocateBuffer(GL11.GL_LINES);
+    }
+
+    @Override
+    public void draw(MatrixStack matrixStack)
+    {
+        this.preRender();
+
+        this.renderObjects.get(0).draw(matrixStack);
+
+        // Render the lines as quads with glPolygonMode(GL_LINE)
+        RenderSystem.polygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
+        RenderSystem.disableBlend();
+        this.renderObjects.get(0).draw(matrixStack);
+        RenderSystem.polygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL);
+        RenderSystem.enableBlend();
+    }
+
+    @Override
+    public JsonObject toJson()
+    {
+        JsonObject obj = super.toJson();
+        if (obj != null) {
+            obj.add("destination", JsonUtils.vec3dToJson(this.destination));
+            obj.add("color", new JsonPrimitive(this.color.intValue));
+        }
+        return obj;
+    }
+
+    @Override
+    public void fromJson(JsonObject obj)
+    {
+        super.fromJson(obj);
+
+        Vec3d destination = JsonUtils.vec3dFromJson(obj, "destination");
+
+        if (destination != null)
+        {
+            this.setDestination(destination);
+        }
+
+        if (JsonUtils.hasInteger(obj, "color"))
+        {
+            this.color = Color4f.fromColor(JsonUtils.getInteger(obj, "color"));
+        }
+    }
+
+    @Override
+    public List<String> getWidgetHoverLines()
+    {
+        List<String> lines = new ArrayList<>();
+        Vec3d c = this.destination;
+        lines.add(StringUtils.translate("minihud.gui.label.destination_value", String.format("x: %.2f, y: %.2f, z: %.2f", c.x, c.y, c.z)));
+
+        return lines;
+    }
+
+    protected void renderLine(Vec3d cameraPos)
+    {
+        RenderObjectBase renderQuads = this.renderObjects.get(0);
+
+        // playerDiff should be playerPos.subtract(cameraPos),
+        // so it stays in the player, even if the camera mode (F5) is changed
+        // but I don't know why its very laggy to call this.mc.player.getPos
+        Vec3d playerDiff = new Vec3d(0d, -1d, 0d);
+        Vec3d destDiff = this.destination.subtract(cameraPos);
+
+        // perpendicular offset that will give the width of the line
+        Vec3d offset = new Vec3d(destDiff.getX(), 0d, destDiff.getZ())
+                .normalize()
+                .multiply(WIDTH / 2)
+                .rotateY((float) Math.toRadians(90));
+
+        BUFFER_1.begin(renderQuads.getGlMode(), VertexFormats.POSITION_COLOR);
+
+        BUFFER_1.vertex(destDiff.getX() - offset.getX(), destDiff.getY(), destDiff.getZ()  - offset.getZ()).color(color.r, color.g, color.b, color.a).next();
+        BUFFER_1.vertex(destDiff.getX() + offset.getX(), destDiff.getY(), destDiff.getZ() + offset.getZ()).color(color.r, color.g, color.b, color.a).next();
+        BUFFER_1.vertex(playerDiff.getX() + offset.getX(), playerDiff.getY(), playerDiff.getZ() + offset.getZ()).color(color.r, color.g, color.b, color.a).next();
+        BUFFER_1.vertex(playerDiff.getX() - offset.getX(), playerDiff.getY(), playerDiff.getZ() - offset.getZ()).color(color.r, color.g, color.b, color.a).next();
+
+        BUFFER_1.end();
+
+        renderQuads.uploadData(BUFFER_1);
+    }
+}

--- a/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeNavigationLine.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeNavigationLine.java
@@ -69,7 +69,7 @@ public class ShapeNavigationLine extends ShapeBase
     @Override
     public void allocateGlResources()
     {
-        this.allocateBuffer(GL11.GL_LINES);
+        this.allocateBuffer(GL11.GL_QUADS);
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeType.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeType.java
@@ -10,7 +10,8 @@ public enum ShapeType
     SPHERE_BLOCKY       ("sphere_blocky",       "minihud.label.shapes.sphere_blocky",       ShapeSphereBlocky::new),
     CAN_SPAWN_SPHERE    ("can_spawn_sphere",    "minihud.label.shapes.can_spawn_sphere",    ShapeCanSpawnSphere::new),
     CAN_DESPAWN_SPHERE  ("can_despawn_sphere",  "minihud.label.shapes.can_despawn_sphere",  ShapeCanDespawnSphere::new),
-    DESPAWN_SPHERE      ("despawn_sphere",      "minihud.label.shapes.despawn_sphere",      ShapeDespawnSphere::new);
+    DESPAWN_SPHERE      ("despawn_sphere",      "minihud.label.shapes.despawn_sphere",      ShapeDespawnSphere::new),
+    NAVIGATION_LINE     ("navigation_line",     "minihud.label.shapes.navigation_line",     ShapeNavigationLine::new);
 
     private final String id;
     private final String translationKey;

--- a/src/main/resources/assets/minihud/lang/en_us.json
+++ b/src/main/resources/assets/minihud/lang/en_us.json
@@ -32,6 +32,8 @@
     "minihud.gui.label.render_type_colon": "Render Type:",
     "minihud.gui.label.shape.block_snap": "Block snap: %s",
     "minihud.gui.label.shape.type_value": "Type: %s",
+    "minihud.gui.label.destination_colon": "Destination:",
+    "minihud.gui.label.destination_value": "Destination: %s",
 
     "minihud.gui.label.hover.shape.block_snap": "§7Block snap: §b%s",
     "minihud.gui.label.hover.shape.center_value": "§7Center - x: §9%s§7, y: §9%s§7, z: §9%s",
@@ -74,6 +76,7 @@
     "minihud.label.shapes.circle": "Circle / Cylinder",
     "minihud.label.shapes.despawn_sphere": "Despawn Sphere ( > 128)",
     "minihud.label.shapes.sphere_blocky": "Sphere (block-based)",
+    "minihud.label.shapes.navigation_line": "Navigation Line",
 
     "minihud.hotkeys.category.generic_hotkeys": "Generic hotkeys",
     "minihud.hotkeys.category.info_toggle_hotkeys": "Info Toggle hotkeys",


### PR DESCRIPTION
Add navigation line to find a coordinate quicker. For example, we can add coordinate for buried treasure then go to the correct coordinate easily:

![2021-02-14_23 12 36](https://user-images.githubusercontent.com/20378156/107882218-ad2a5e80-6f1a-11eb-9a23-dc48920a5328.png)
![2021-02-14_23 12 13](https://user-images.githubusercontent.com/20378156/107882215-a865aa80-6f1a-11eb-8ef2-1f00115fd196.png)

This is my own addition, maybe someone / the author is interested. Im not sure how to run and test on other launcher, so this is only tested in fabric 1.16.4.

Possible improvement:
- use line instead of `GL_QUADS`, then adjust the thickness of the line
- show text of the navigation name on the destination, without scaled down, so player can manage multiple coordinates easily
- set the beginning of the line to player position instead of camera position, for better view on other F5 mode.
