### PR TITLE
Added infoHorseSpeed and infoHorseJump toggles

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/config/InfoToggle.java
+++ b/src/main/java/fi/dy/masa/minihud/config/InfoToggle.java
@@ -34,6 +34,8 @@ public enum InfoToggle implements IConfigInteger, IHotkeyTogglable
     FACING                  ("infoFacing",                  true,   8, "", "Show the player's current facing"),
     FPS                     ("infoFPS",                     false,  0, "", "Show the current FPS"),
     HONEY_LEVEL             ("infoHoneyLevel",              false, 37, "", "Show the honey level the targeted Hive or Nest.\nNote: This only works in single player without server-side support."),
+    HORSE_SPEED             ("infoHorseSpeed",              false, 36, "", "Show the speed (m/s) of the horse being ridden."),
+    HORSE_JUMP             ("infoHorseJump",                false, 37, "", "Show the jump height of the horse being ridden."),
     LIGHT_LEVEL             ("infoLightLevel",              false, 10, "", "Show the current light level"),
     LOOKING_AT_BLOCK        ("infoLookingAtBlock",          false, 25, "", "Show which block the player is currently looking at"),
     LOOKING_AT_BLOCK_CHUNK  ("infoLookingAtBlockInChunk",   false, 26, "", "Show which block within its containing chunk\nthe player is currently looking at"),

--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -589,6 +589,7 @@ public class RenderHandler implements IRenderer
             }
 
             HorseBaseEntity horse = (HorseBaseEntity) vehicle;
+            if (!horse.isSaddled()) return;
 
 
             if (InfoToggle.HORSE_SPEED.getBooleanValue()) {

--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -22,6 +22,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.HorseBaseEntity;
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -570,6 +571,44 @@ public class RenderHandler implements IRenderer
             {
                 this.addLine("Honey: " + GuiBase.TXT_AQUA + BeehiveBlockEntity.getHoneyLevel(state));
             }
+        }
+        else if (type == InfoToggle.HORSE_SPEED ||
+                 type == InfoToggle.HORSE_JUMP)
+        {
+            if (this.addedTypes.contains(InfoToggle.HORSE_SPEED) ||
+                this.addedTypes.contains(InfoToggle.HORSE_JUMP))
+            {
+                return;
+            }
+
+            Entity vehicle = this.mc.player.getVehicle();
+
+            if (!(vehicle instanceof HorseBaseEntity))
+            {
+                return;
+            }
+
+            HorseBaseEntity horse = (HorseBaseEntity) vehicle;
+
+
+            if (InfoToggle.HORSE_SPEED.getBooleanValue()) {
+                float speed = horse.getMovementSpeed();
+                speed *= 42.163f;
+                this.addLine(String.format("Horse Speed: %.3f m/s", speed));
+            }
+
+            if (InfoToggle.HORSE_JUMP.getBooleanValue()) {
+                double jump = horse.getJumpStrength();
+                double calculatedJumpHeight =
+                        -0.1817584952d * jump * jump * jump +
+                        3.689713992d * jump * jump +
+                        2.128599134d * jump +
+                        -0.343930367;
+                this.addLine(String.format("Horse Jump: %.3f m", calculatedJumpHeight));
+            }
+
+            this.addedTypes.add(InfoToggle.HORSE_SPEED);
+            this.addedTypes.add(InfoToggle.HORSE_JUMP);
         }
         else if (type == InfoToggle.ROTATION_YAW ||
                  type == InfoToggle.ROTATION_PITCH ||


### PR DESCRIPTION
What the title says, adds toggles to show the calculated jump height and speed of the horse being ridden by the player. It checks for `HorseBaseEntity`, meaning that donkeys, mules, etc. are included.