### PR TITLE
Adding Observer Neighbor Update to neighbor update renderer

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/mixin/MixinObserverBlock.java
+++ b/src/main/java/fi/dy/masa/minihud/mixin/MixinObserverBlock.java
@@ -1,0 +1,22 @@
+package fi.dy.masa.minihud.mixin;
+
+import fi.dy.masa.minihud.util.DebugInfoUtils;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.FacingBlock;
+import net.minecraft.block.ObserverBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ObserverBlock.class)
+public class MixinObserverBlock {
+
+    @Inject(method = "updateNeighbors", at = @At("HEAD"))
+    public void onNotifyNeighbors(World world, BlockPos pos, BlockState state, CallbackInfo ci)
+    {
+        DebugInfoUtils.onNeighborNotify(world, pos, EnumSet.of(state.get(FacingBlock.FACING).getOpposite()));
+    }
+}

--- a/src/main/resources/mixins.minihud.json
+++ b/src/main/resources/mixins.minihud.json
@@ -18,6 +18,7 @@
         "MixinMinecraftClient",
         "MixinMinecraftServer",
         "MixinNeighborUpdateDebugRenderer",
+        "MixinObserverBlock",
         "MixinScreen",
         "MixinServerEntityManager",
         "MixinSubtitlesHud",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28154542/130694415-f339c5dd-3574-4dee-a64a-8ca1cc57aef5.png)
The observer was missing in the neighbor update renderer. This is just a quick fix to add it!