### PR TITLE
Fixing onNeighborNotify

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/util/DebugInfoUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/DebugInfoUtils.java
@@ -130,7 +130,7 @@ public class DebugInfoUtils
             Minecraft.getMinecraft().addScheduledTask(() -> {
                 for (EnumFacing side : notifiedSides)
                 {
-                    ((DebugRendererNeighborsUpdate) Minecraft.getMinecraft().debugRenderer.neighborsUpdate).addUpdate(time, pos.offset(side));
+                    ((DebugRendererNeighborsUpdate) Minecraft.getMinecraft().debugRenderer.neighborsUpdate).addUpdate(time, pos.mutableCopy().offset(side));
                 }
             });
         }


### PR DESCRIPTION
Fixing onNeighborNotify not displaying correctly for trees due to a mutable being passed through