### PR TITLE
Add extra Light Level features for 1.18.1

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/config/Configs.java
+++ b/src/main/java/fi/dy/masa/minihud/config/Configs.java
@@ -58,7 +58,8 @@ public class Configs implements IConfigHandler
         public static final ConfigDouble        LIGHT_LEVEL_NUMBER_OFFSET_SKY_Y     = new ConfigDouble("lightLevelNumberOffsetSkyY", 0.56, 0.0, 1.0, "The relative \"y\" offset for the sky light level number.\nRange: 0.0 - 1.0");
         public static final ConfigBoolean       LIGHT_LEVEL_NUMBER_ROTATION         = new ConfigBoolean("lightLevelNumberRotation", true, "If true, then the light level numbers will rotate\naccording to the player's current facing");
         public static final ConfigInteger       LIGHT_LEVEL_RANGE                   = new ConfigInteger("lightLevelRange", 24, 1, 64, "The block range to render the Light Level overlay in");
-        public static final ConfigInteger       LIGHT_LEVEL_THRESHOLD               = new ConfigInteger("lightLevelThreshold", 8, 0, 15, "The light level threshold which is considered safe");
+        public static final ConfigInteger       LIGHT_LEVEL_THRESHOLD               = new ConfigInteger("lightLevelThreshold", 8, 0, 15, "The minimum light level which is considered safe");
+        public static final ConfigInteger       LIGHT_LEVEL_SPAWNABLE_THRESHOLD     = new ConfigInteger("lightLevelSpawnableThreshold", 0, 0, 15, "The maximim light level which is considered spawnable");
         public static final ConfigDouble        LIGHT_LEVEL_Z_OFFSET                = new ConfigDouble("lightLevelZOffset", 0.005, 0.0, 1.0, "The relative \"z\" offset for the light level overlay.\nMeant to help with potential z-fighting issues.\nRange: 0.0 - 1.0");
         public static final ConfigBoolean       MAP_PREVIEW                         = new ConfigBoolean("mapPreview", false, "Enables rendering a preview of the map,\nwhen you hold shift while hovering over a map item");
         public static final ConfigInteger       MAP_PREVIEW_SIZE                    = new ConfigInteger("mapPreviewSize", 160, 16, 512, "The size of the rendered map previews");

--- a/src/main/java/fi/dy/masa/minihud/config/Configs.java
+++ b/src/main/java/fi/dy/masa/minihud/config/Configs.java
@@ -152,12 +152,14 @@ public class Configs implements IConfigHandler
     public static class Colors
     {
         public static final ConfigColor BLOCK_GRID_OVERLAY_COLOR                = new ConfigColor("blockGridOverlayColor",              "#80FFFFFF", "Color for the block grid overlay");
-        public static final ConfigColor LIGHT_LEVEL_MARKER_DARK                 = new ConfigColor("lightLevelMarkerDark",               "#FFFF4848", "The color for the spawnable spots marker");
-        public static final ConfigColor LIGHT_LEVEL_MARKER_LIT                  = new ConfigColor("lightLevelMarkerLit",                "#FFFFFF33", "The color for the safe (during day) spots marker");
-        public static final ConfigColor LIGHT_LEVEL_NUMBER_BLOCK_DARK           = new ConfigColor("lightLevelNumberBlockDark",          "#FFC03030", "The color for the spawnable spots number of the block light value");
-        public static final ConfigColor LIGHT_LEVEL_NUMBER_BLOCK_LIT            = new ConfigColor("lightLevelNumberBlockLit",           "#FF209040", "The color for the safe spots number of the block light value");
-        public static final ConfigColor LIGHT_LEVEL_NUMBER_SKY_DARK             = new ConfigColor("lightLevelNumberSkyDark",            "#FFFFF030", "The color for the spawnable spots number of the sky light value");
-        public static final ConfigColor LIGHT_LEVEL_NUMBER_SKY_LIT              = new ConfigColor("lightLevelNumberSkyLit",             "#FF40E0FF", "The color for the safe spots number of the sky light value");
+        public static final ConfigColor LIGHT_LEVEL_MARKER_DARK                 = new ConfigColor("lightLevelMarkerDark",               "#FFFF4848", "The color for the spawnable spots' marker");
+        public static final ConfigColor LIGHT_LEVEL_MARKER_LIT                  = new ConfigColor("lightLevelMarkerLit",                "#FFFFFF33", "The color for the safe (during day) spots' marker");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_BLOCK_DARK           = new ConfigColor("lightLevelNumberBlockDark",          "#FFC03030", "The color for the spawnable spots' number of the block light value");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_BLOCK_DIM            = new ConfigColor("lightLevelNumberBlockDim",           "#FFF0F000", "The color for the safe spots' number of the block light value below the configured threshold");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_BLOCK_LIT            = new ConfigColor("lightLevelNumberBlockLit",           "#FF808020", "The color for the safe spots' number of the block light value");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_SKY_DARK             = new ConfigColor("lightLevelNumberSkyDark",            "#FF3030FF", "The color for the spawnable spots' number of the sky light value");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_SKY_DIM              = new ConfigColor("lightLevelNumberSkyDim",             "#FFFF6030", "The color for the safe spots' number of the sky light value below the configured threshold");
+        public static final ConfigColor LIGHT_LEVEL_NUMBER_SKY_LIT              = new ConfigColor("lightLevelNumberSkyLit",             "#FF40E0FF", "The color for the safe spots' number of the sky light value");
         public static final ConfigColor RANDOM_TICKS_FIXED_OVERLAY_COLOR        = new ConfigColor("randomTicksFixedOverlayColor",       "#30F9F225", "Color for the fixed-point random ticked chunks overlay");
         public static final ConfigColor RANDOM_TICKS_PLAYER_OVERLAY_COLOR       = new ConfigColor("randomTicksPlayerOverlayColor",      "#3030FE73", "Color for the player-following random ticked chunks overlay");
         public static final ConfigColor REGION_OVERLAY_COLOR                    = new ConfigColor("regionOverlayColor",                 "#30FF8019", "Color for the region file overlay");

--- a/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererLightLevel.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererLightLevel.java
@@ -139,6 +139,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
                         Configs.Generic.LIGHT_LEVEL_NUMBER_OFFSET_BLOCK_Y,
                         Configs.Colors.LIGHT_LEVEL_NUMBER_BLOCK_LIT,
                         Configs.Colors.LIGHT_LEVEL_NUMBER_BLOCK_DARK,
+                        Configs.Colors.LIGHT_LEVEL_NUMBER_BLOCK_DIM,
                         useColoredNumbers, lightThreshold, numberFacing, bufferQuads);
             }
 
@@ -149,6 +150,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
                         Configs.Generic.LIGHT_LEVEL_NUMBER_OFFSET_SKY_Y,
                         Configs.Colors.LIGHT_LEVEL_NUMBER_SKY_LIT,
                         Configs.Colors.LIGHT_LEVEL_NUMBER_SKY_DARK,
+                        Configs.Colors.LIGHT_LEVEL_NUMBER_SKY_DIM,
                         useColoredNumbers, lightThreshold, numberFacing, bufferQuads);
             }
 
@@ -164,14 +166,14 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
     }
 
     private void renderNumbers(Vec3d cameraPos, LightLevelNumberMode mode, IConfigDouble cfgOffX, IConfigDouble cfgOffZ,
-            ConfigColor cfgColorLit, ConfigColor cfgColorDark, boolean useColoredNumbers,
+            ConfigColor cfgColorLit, ConfigColor cfgColorDark, ConfigColor cfgColorDim, boolean useColoredNumbers,
             int lightThreshold, Direction numberFacing, BufferBuilder buffer)
     {
         double ox = cfgOffX.getDoubleValue();
         double oz = cfgOffZ.getDoubleValue();
         double tmpX, tmpZ;
         double offsetY = Configs.Generic.LIGHT_LEVEL_Z_OFFSET.getDoubleValue();
-        Color4f colorLit, colorDark;
+        Color4f colorLit, colorDark, colorDim;
 
         switch (numberFacing)
         {
@@ -186,14 +188,16 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
         {
             colorLit = cfgColorLit.getColor();
             colorDark = cfgColorDark.getColor();
+            colorDim = cfgColorDim.getColor();
         }
         else
         {
             colorLit = Color4f.fromColor(0xFFFFFFFF);
             colorDark = Color4f.fromColor(0xFFFFFFFF);
+            colorDim = Color4f.fromColor(0xFFFFFFFF);
         }
 
-        this.renderLightLevelNumbers(tmpX + cameraPos.x, cameraPos.y - offsetY, tmpZ + cameraPos.z, numberFacing, lightThreshold, mode, colorLit, colorDark, buffer);
+        this.renderLightLevelNumbers(tmpX + cameraPos.x, cameraPos.y - offsetY, tmpZ + cameraPos.z, numberFacing, lightThreshold, mode, colorLit, colorDark, colorDim, buffer);
     }
 
     private void renderMarkers(IMarkerRenderer renderer, Vec3d cameraPos, int lightThreshold, BufferBuilder buffer)
@@ -201,6 +205,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
         double markerSize = Configs.Generic.LIGHT_LEVEL_MARKER_SIZE.getDoubleValue();
         Color4f colorLit = Configs.Colors.LIGHT_LEVEL_MARKER_LIT.getColor();
         Color4f colorDark = Configs.Colors.LIGHT_LEVEL_MARKER_DARK.getColor();
+        Color4f colorDim = Configs.Colors.LIGHT_LEVEL_MARKER_DIM.getColor();
         double offsetX = cameraPos.x;
         double offsetY = cameraPos.y - Configs.Generic.LIGHT_LEVEL_Z_OFFSET.getDoubleValue();
         double offsetZ = cameraPos.z;
@@ -215,7 +220,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
             if (info.block < lightThreshold)
             {
                 BlockPos pos = info.pos;
-                Color4f color = info.sky >= lightThreshold ? colorLit : colorDark;
+                Color4f color = info.sky >= lightThreshold ? colorLit : lightLevel == 0 ? colorDark : colorDim;
                 renderer.render(pos.getX() - offsetX, pos.getY() - offsetY, pos.getZ() - offsetZ, color, offset1, offset2, buffer);
             }
         }
@@ -223,7 +228,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
 
     private void renderLightLevelNumbers(double dx, double dy, double dz, Direction facing,
             int lightThreshold, LightLevelNumberMode numberMode,
-            Color4f colorLit, Color4f colorDark, BufferBuilder buffer)
+            Color4f colorLit, Color4f colorDark, Color4f colorDim, BufferBuilder buffer)
     {
         final int count = this.lightInfos.size();
 
@@ -235,7 +240,7 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
             double y = pos.getY() - dy;
             double z = pos.getZ() - dz;
             int lightLevel = numberMode == LightLevelNumberMode.BLOCK ? info.block : info.sky;
-            Color4f color = lightLevel >= lightThreshold ? colorLit : colorDark;
+            Color4f color = lightLevel >= lightThreshold ? colorLit : lightLevel == 0 ? colorDark : colorDim;
 
             this.renderLightLevelTextureColor(x, y, z, facing, lightLevel, color, buffer);
         }

--- a/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererLightLevel.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererLightLevel.java
@@ -156,11 +156,11 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
 
             if (markerMode == LightLevelMarkerMode.SQUARE)
             {
-                this.renderMarkers(this::renderLightLevelSquare, cameraPos, lightThreshold, bufferLines);
+                this.renderMarkers(this::renderLightLevelSquare, cameraPos, bufferLines);
             }
             else if (markerMode == LightLevelMarkerMode.CROSS)
             {
-                this.renderMarkers(this::renderLightLevelCross, cameraPos, lightThreshold, bufferLines);
+                this.renderMarkers(this::renderLightLevelCross, cameraPos, bufferLines);
             }
         }
     }
@@ -200,12 +200,12 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
         this.renderLightLevelNumbers(tmpX + cameraPos.x, cameraPos.y - offsetY, tmpZ + cameraPos.z, numberFacing, lightThreshold, mode, colorLit, colorDark, colorDim, buffer);
     }
 
-    private void renderMarkers(IMarkerRenderer renderer, Vec3d cameraPos, int lightThreshold, BufferBuilder buffer)
+    private void renderMarkers(IMarkerRenderer renderer, Vec3d cameraPos, BufferBuilder buffer)
     {
+        int spawnThreshold = Configs.Generic.LIGHT_LEVEL_SPAWNABLE_THRESHOLD.getIntegerValue();
         double markerSize = Configs.Generic.LIGHT_LEVEL_MARKER_SIZE.getDoubleValue();
         Color4f colorLit = Configs.Colors.LIGHT_LEVEL_MARKER_LIT.getColor();
         Color4f colorDark = Configs.Colors.LIGHT_LEVEL_MARKER_DARK.getColor();
-        Color4f colorDim = Configs.Colors.LIGHT_LEVEL_MARKER_DIM.getColor();
         double offsetX = cameraPos.x;
         double offsetY = cameraPos.y - Configs.Generic.LIGHT_LEVEL_Z_OFFSET.getDoubleValue();
         double offsetZ = cameraPos.z;
@@ -216,13 +216,9 @@ public class OverlayRendererLightLevel extends OverlayRendererBase
         for (int i = 0; i < count; ++i)
         {
             LightLevelInfo info = this.lightInfos.get(i);
-
-            if (info.block < lightThreshold)
-            {
-                BlockPos pos = info.pos;
-                Color4f color = info.sky >= lightThreshold ? colorLit : lightLevel == 0 ? colorDark : colorDim;
-                renderer.render(pos.getX() - offsetX, pos.getY() - offsetY, pos.getZ() - offsetZ, color, offset1, offset2, buffer);
-            }
+            BlockPos pos = info.pos;
+            Color4f color = (info.sky > spawnThreshold || info.block > spawnThreshold) ? colorLit : colorDark;
+            renderer.render(pos.getX() - offsetX, pos.getY() - offsetY, pos.getZ() - offsetZ, color, offset1, offset2, buffer);
         }
     }
 


### PR DESCRIPTION
Based on the idea that In 1.18 many people might want a visual cue when the light level is below a certain threshold, even if the light level is not spawnable, since the spawnable light level is 0 in 1.18.

Also cleans up the code a bit and fixes a bug with the marker code.

**NOTE:** I haven't tested it in-game since i don't have Fabric 1.17 installed anymore, but if you need me to test it before merging i will, just say so.