### PR TITLE
Add {TICK} option to the world time formatter

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -347,6 +347,7 @@ public class RenderHandler implements IRenderer
                 str = str.replace("{HOUR}", String.format("%02d", hour));
                 str = str.replace("{MIN}",  String.format("%02d", min));
                 str = str.replace("{SEC}",  String.format("%02d", sec));
+                str = str.replace("{TICK}",  String.format("%d", dayTicks));
 
                 this.addLine(str);
             }


### PR DESCRIPTION
This merge request adds the option to show the current tick of the day to the time formatter. Useful because right now to show both (world time in hours, minutes, etc and day tick), you have to add another line to the info screen, with this it will be one one.

![image](https://user-images.githubusercontent.com/3914859/150693820-3981e5d1-a2c1-4d18-a715-fdb8447c19db.png)

![image](https://user-images.githubusercontent.com/3914859/150693835-0c31fbe4-dcc1-4e7b-85f9-c479fab4e5c1.png)
