### PR TITLE
Use the fps value in MinecraftClient instead of updateFps() method

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -124,10 +124,6 @@ public class RenderHandler implements IRenderer
             (Configs.Generic.REQUIRE_SNEAK.getBooleanValue() == false || this.mc.player.isSneaking()) &&
             Configs.Generic.REQUIRED_KEY.getKeybind().isKeybindHeld())
         {
-            if (InfoToggle.FPS.getBooleanValue())
-            {
-                this.updateFps();
-            }
 
             long currentTime = System.currentTimeMillis();
 
@@ -193,19 +189,6 @@ public class RenderHandler implements IRenderer
         }
 
         return 0;
-    }
-
-    private void updateFps()
-    {
-        this.fpsCounter++;
-        long time = System.currentTimeMillis();
-
-        if (time >= (this.fpsUpdateTime + 1000L))
-        {
-            this.fpsUpdateTime = time;
-            this.fps = this.fpsCounter;
-            this.fpsCounter = 0;
-        }
     }
 
     public void updateData(MinecraftClient mc)
@@ -296,7 +279,7 @@ public class RenderHandler implements IRenderer
 
         if (type == InfoToggle.FPS)
         {
-            this.addLine(String.format("%d fps", this.fps));
+            this.addLine(String.format("%d fps", MinecraftClient.getInstance().getCurrentFps()));
         }
         else if (type == InfoToggle.MEMORY_USAGE)
         {


### PR DESCRIPTION
This mod is incompatible with [exordium](https://www.curseforge.com/minecraft/mc-mods/exordium). When installed exordium, the miniHUD huds are not rendered every render tick, and then the fps value of miniHUD is not the real fps of minecraft.

Just use `net.minecraft.client.MinecraftClient#getCurrentFps` to get the correct fps value.