### PR TITLE
Use player pos instead of entity pos

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererRandomTickableChunks.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererRandomTickableChunks.java
@@ -71,7 +71,7 @@ public class OverlayRendererRandomTickableChunks extends OverlayRendererBase
     {
         if (this.toggle == RendererToggle.OVERLAY_RANDOM_TICKS_PLAYER)
         {
-            this.pos = entity.getPos();
+            this.pos = mc.player.getPos();
         }
         else if (newPos != null)
         {


### PR DESCRIPTION
Use the player position from the passed minecraft client object instead of the entity from the update call when rendering using the RANDOM_TICKS_PLAYER